### PR TITLE
group together route stats by fastify route config context

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,31 +13,31 @@ npm i fastify-routes-stats
 ## Example
 
 ```js
-'use strict';
+'use strict'
 
-const Fastify = require('fastify');
-const fastify = Fastify();
+const Fastify = require('fastify')
+const fastify = Fastify()
 
-fastify.register(require('.'));
+fastify.register(require('.'))
 
 fastify.get('/', function(request, reply) {
-  reply.send({ hello: 'world' });
-});
+  reply.send({ hello: 'world' })
+})
 
 fastify.get(
   '/:param/dynamic-route-example',
   { config: { statsId: 'group-stats-together' } },
   function(request, reply) {
-    reply.send({ hello: 'world' });
+    reply.send({ hello: 'world' })
   }
-);
+)
 
 fastify.get('/__stats__', async function() {
   // stats is added to the fastify instance
-  return this.stats();
-});
+  return this.stats()
+})
 
-fastify.listen(3000);
+fastify.listen(3000)
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/fastify/fastify-routes-stats.svg)](https://greenkeeper.io/)
 
-Provide stats for routes using `require('perf_hooks')`, for __Fastify__.
+Provide stats for routes using `require('perf_hooks')`, for **Fastify**.
 
 ## Install
 
@@ -13,27 +13,31 @@ npm i fastify-routes-stats
 ## Example
 
 ```js
-'use strict'
+'use strict';
 
-const Fastify = require('fastify')
-const fastify = Fastify()
+const Fastify = require('fastify');
+const fastify = Fastify();
 
-fastify.register(require('.'))
+fastify.register(require('.'));
 
-fastify.get('/', function (request, reply) {
-  reply.send({ hello: 'world' })
-})
+fastify.get('/', function(request, reply) {
+  reply.send({ hello: 'world' });
+});
 
-fastify.get('/:param/dynamic-route-example', { config: { statsId: 'group-stats-together' } }, function (request, reply) {
-  reply.send({ hello: 'world' })
-})
+fastify.get(
+  '/:param/dynamic-route-example',
+  { config: { statsId: 'group-stats-together' } },
+  function(request, reply) {
+    reply.send({ hello: 'world' });
+  }
+);
 
-fastify.get('/__stats__', async function () {
+fastify.get('/__stats__', async function() {
   // stats is added to the fastify instance
-  return this.stats()
-})
+  return this.stats();
+});
 
-fastify.listen(3000)
+fastify.listen(3000);
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ fastify.get('/', function (request, reply) {
   reply.send({ hello: 'world' })
 })
 
+fastify.get('/:param/dynamic-route-example', { config: { statsId: 'group-stats-together' } }, function (request, reply) {
+  reply.send({ hello: 'world' })
+})
+
 fastify.get('/__stats__', async function () {
   // stats is added to the fastify instance
   return this.stats()
@@ -53,6 +57,14 @@ $ curl localhost:3000/__stats__ | jsonlint
     "max": 0.146983,
     "min": 0.052685,
     "sd": 0.048831576955900166
+  },
+  "group-stats-together": {
+    "mean": 0.07447716666666666,
+    "mode": 0.102686,
+    "median": 0.07249649999999999,
+    "max": 0.102686,
+    "min": 0.051836,
+    "sd": 0.01924915148692707
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ const fastify = Fastify()
 
 fastify.register(require('.'))
 
-fastify.get('/', function(request, reply) {
+fastify.get('/', function (request, reply) {
   reply.send({ hello: 'world' })
 })
 
 fastify.get(
   '/:param/dynamic-route-example',
   { config: { statsId: 'group-stats-together' } },
-  function(request, reply) {
+  function (request, reply) {
     reply.send({ hello: 'world' })
   }
 )
 
-fastify.get('/__stats__', async function() {
+fastify.get('/__stats__', async function () {
   // stats is added to the fastify instance
   return this.stats()
 })

--- a/example.js
+++ b/example.js
@@ -11,6 +11,10 @@ fastify.get('/', function (request, reply) {
   reply.send({ hello: 'world' })
 })
 
+fastify.get('/:param/dynamic-route-example', { config: { statsId: 'group-stats-together' } }, function (request, reply) {
+  reply.send({ hello: 'world' })
+})
+
 fastify.get('/__stats__', function (request, reply) {
   reply.send(this.stats())
 })

--- a/index.js
+++ b/index.js
@@ -16,9 +16,13 @@ module.exports = fp(async function (fastify, opts) {
   })
 
   fastify.addHook('onSend', function (request, reply, _, next) {
+    let routeId = request.raw.url
+    if (reply.context.config.statsId) {
+      routeId = reply.context.config.statsId
+    }
     const id = request.raw.id
     performance.mark(ONSEND + id)
-    performance.measure(ROUTES + request.raw.url, PREHANDLER + id, ONSEND + id)
+    performance.measure(ROUTES + routeId, PREHANDLER + id, ONSEND + id)
 
     performance.clearMarks(ONSEND + id)
     performance.clearMarks(PREHANDLER + id)

--- a/test.js
+++ b/test.js
@@ -91,3 +91,37 @@ test('creates stats', async (t) => {
   t.ok(nums.min >= 0)
   t.ok(nums.sd >= 0)
 })
+
+test('group stats together', async (t) => {
+  const fastify = Fastify()
+  fastify.register(Stats)
+
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.get('/:param/grouped-stats', { config: { statsId: 'grouped-stats' } }, async () => {
+    return { hello: 'world' }
+  })
+
+  await fastify.inject({
+    url: '/1/grouped-stats'
+  })
+
+  await fastify.inject({
+    url: '/2/grouped-stats'
+  })
+
+  await fastify.inject({
+    url: '/3/grouped-stats'
+  })
+
+  const stats = fastify.stats()
+  const nums = stats['grouped-stats']
+  t.ok(Object.keys(stats).length === 1)
+  t.ok(nums)
+  t.ok(nums.mean >= 0)
+  t.ok(nums.mode >= 0)
+  t.ok(nums.median >= 0)
+  t.ok(nums.max >= 0)
+  t.ok(nums.min >= 0)
+  t.ok(nums.sd >= 0)
+})


### PR DESCRIPTION
Following an issue I raised: https://github.com/fastify/fastify-routes-stats/issues/3

This will now allow users to group together performance metrics using Fastify route config.

```JavaScript
fastify.get('/:param/dynamic-route-example', { config: { statsId: 'group-stats-together' } }, function (request, reply) {
  reply.send({ hello: 'world' })
})
```