### PR TITLE
Rename module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fastify-routes-stats",
-  "version": "2.0.1",
+  "name": "@fastify/routes-stats",
+  "version": "3.0.0",
   "description": "provide stats for routes using perf_hooks, for fastify",
   "main": "index.js",
   "scripts": {
@@ -41,5 +41,8 @@
     "hooks": {
       "pre-commit": "npm test"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This pull request renames the module according to the discussion in
https://github.com/fastify/fastify/issues/3733.

Note that the deprecation module has _already been published_ and that the
code for it does not exist in this repository. The code for the published
deprecation module was generated by https://github.com/fastify/deprecate-modules
and run on @jsumners local system.

Coordinating the drastic changes to the code for the module deprecation and
then restoring the code for the module renaming would have been extremely
difficult and prohibitively tedious.

**Important:** no further releases should be added to the old major version.
