### PR TITLE
check if a request id exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ const fastify = Fastify()
 
 fastify.register(require('@fastify/routes-stats'), {
   printInterval: 4000, // milliseconds
+  decoratorName: "performanceMark", // decorator is set to true if a performace.mark was called for the request
 })
 
 fastify.get('/', function (request, reply) {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const fastify = Fastify()
 
 fastify.register(require('@fastify/routes-stats'), {
   printInterval: 4000, // milliseconds
-  decoratorName: "performanceMark", // decorator is set to true if a performace.mark was called for the request
+  decoratorName: "performanceMarked", // decorator is set to true if a performace.mark was called for the request
 })
 
 fastify.get('/', function (request, reply) {

--- a/index.js
+++ b/index.js
@@ -52,8 +52,7 @@ async function fastifyRoutesStats (fastify, opts) {
   fastify.decorateRequest(decoratorName, false)
 
   fastify.addHook('onRequest', function (request, reply, next) {
-    const id = request.id
-    performance.mark(ONREQUEST + id)
+    performance.mark(ONREQUEST + request.id)
     request[decoratorName] = true
     next()
   })

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const ROUTES = 'fastify-routes:'
 
 async function fastifyRoutesStats (fastify, opts) {
   let observedEntries = {}
-  const { decoratorName = 'performanceMark' } = opts
+  const { decoratorName = 'performanceMarked' } = opts
   const obs = new PerformanceObserver((items) => {
     const fetchedItems = items.getEntries()
     for (let i = 0, il = fetchedItems.length; i < il; ++i) {

--- a/index.js
+++ b/index.js
@@ -58,19 +58,18 @@ async function fastifyRoutesStats (fastify, opts) {
   })
 
   fastify.addHook('onSend', function (request, reply, _, next) {
-    const routeId = reply.context.config.statsId
-      ? reply.context.config.statsId
-      : request.raw.url
-
-    const id = request.id
-    const key = `${ROUTES}${request.raw.method}|${routeId}`
-
     if (request[decoratorName]) {
+      const routeId = reply.context.config.statsId || request.raw.url
+      const id = request.id
+      const key = `${ROUTES}${request.raw.method}|${routeId}`
+
       performance.mark(ONSEND + id)
       performance.measure(key, ONREQUEST + id, ONSEND + id)
       performance.clearMarks(ONSEND + id)
       performance.clearMarks(ONREQUEST + id)
-    } else fastify.log.error('missing request mark')
+    } else {
+      fastify.log.error('missing request mark')
+    }
 
     next()
   })

--- a/index.js
+++ b/index.js
@@ -59,15 +59,17 @@ async function fastifyRoutesStats (fastify, opts) {
     const routeId = reply.context.config.statsId
       ? reply.context.config.statsId
       : request.raw.url
+    
+    const id = request.raw.id ?? null 
+    if (id) {
+      performance.mark(ONSEND + id)
 
-    const id = request.raw.id
-    performance.mark(ONSEND + id)
+      const key = `${ROUTES}${request.raw.method}|${routeId}`
+      performance.measure(key, ONREQUEST + id, ONSEND + id)
 
-    const key = `${ROUTES}${request.raw.method}|${routeId}`
-    performance.measure(key, ONREQUEST + id, ONSEND + id)
-
-    performance.clearMarks(ONSEND + id)
-    performance.clearMarks(ONREQUEST + id)
+      performance.clearMarks(ONSEND + id)
+      performance.clearMarks(ONREQUEST + id)
+    }
 
     next()
   })

--- a/index.js
+++ b/index.js
@@ -59,17 +59,18 @@ async function fastifyRoutesStats (fastify, opts) {
     const routeId = reply.context.config.statsId
       ? reply.context.config.statsId
       : request.raw.url
-    
-    const id = request.raw.id ?? null 
-    if (id) {
-      performance.mark(ONSEND + id)
 
-      const key = `${ROUTES}${request.raw.method}|${routeId}`
+    const id = request.raw.id
+    performance.mark(ONSEND + id)
+
+    const key = `${ROUTES}${request.raw.method}|${routeId}`
+    try {
       performance.measure(key, ONREQUEST + id, ONSEND + id)
-
-      performance.clearMarks(ONSEND + id)
-      performance.clearMarks(ONREQUEST + id)
+    } catch (e) {
+      fastify.log.error('missing request mark')
     }
+    performance.clearMarks(ONSEND + id)
+    performance.clearMarks(ONREQUEST + id)
 
     next()
   })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,6 +24,11 @@ declare namespace fastifyRoutesStats {
      * @default 30000
      */
     printInterval?: number;
+
+    /**
+     * @default 'performanceMarked'
+     */
+    decoratorName?: string
   }
 
   export const fastifyRoutesStats: FastifyRoutesStats

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -7,6 +7,9 @@ const fastify = Fastify();
 fastify.register(fastifyRoutesStats, { printInterval: 1000 })
 expectError(fastify.register(fastifyRoutesStats, { printInterval: 'a' }))
 
+fastify.register(fastifyRoutesStats, { decoratorName: 'perfMarker' })
+expectError(fastify.register(fastifyRoutesStats, { decoratorName: 1 }))
+
 expectAssignable<Function>(fastify.measurements)
 expectAssignable<Function>(fastify.stats)
 


### PR DESCRIPTION
Fixes #94 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Regarding  https://github.com/fastify/fastify-routes-stats/issues/94 , it checks if an request id exists before setting the onSend mark and making the measurements. 
