### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NPM version](https://img.shields.io/npm/v/@fastify/routes-stats.svg?style=flat)](https://www.npmjs.com/package/@fastify/routes-stats)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
-Provide stats for routes using `require('perf_hooks')`, for **Fastify**.
+Provide stats for routes using `require('node:perf_hooks')`, for **Fastify**.
 
 ## Install
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const { performance, PerformanceObserver } = require('perf_hooks')
+const { performance, PerformanceObserver } = require('node:perf_hooks')
 const processPerformanceList = require('./lib/processPerformanceList')
 
 const ONSEND = 'on-send-'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const { beforeEach, test } = require('tap')
-const { performance } = require('perf_hooks')
-const { Transform } = require('stream')
+const { performance } = require('node:perf_hooks')
+const { Transform } = require('node:stream')
 const Fastify = require('fastify')
 const Stats = require('..')
 const fakeTimer = require('@sinonjs/fake-timers')
-const setTimeoutPromise = require('util').promisify(setTimeout)
+const setTimeoutPromise = require('node:util').promisify(setTimeout)
 
 beforeEach(async () => {
   performance.clearMarks()


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
