### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@fastify/pre-commit": "2.2.0",
     "@sinonjs/fake-timers": "^14.0.0",
     "@types/node": "^22.0.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
     "tap": "^18.7.2",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.