### PR TITLE
test: migrate from tap to node:test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,3 +1,0 @@
-show-full-coverage: true
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "node --test",
     "test:typescript": "tsd"
   },
   "repository": {
@@ -67,7 +67,6 @@
     "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
-    "tap": "^18.7.2",
     "tsd": "^0.31.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "node --test",
+    "test:unit": "c8 -100 node --test",
     "test:typescript": "tsd"
   },
   "repository": {
@@ -64,6 +64,7 @@
     "@fastify/pre-commit": "2.2.0",
     "@sinonjs/fake-timers": "^14.0.0",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.3",
     "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "c8 -100 node --test",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd"
   },
   "repository": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -303,8 +303,6 @@ test('reply sent in a onRequest hook before stats registered', async (t) => {
     next()
   })
 
-  // const match = { msg: /missing request mark/ }
-
   stream.on('data', line => {
     t.assert.match(line.msg, /missing request mark/, 'Line matched')
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { beforeEach, test } = require('tap')
+const { beforeEach, test } = require('node:test')
 const { performance } = require('node:perf_hooks')
 const { Transform } = require('node:stream')
 const Fastify = require('fastify')
@@ -13,10 +13,12 @@ beforeEach(async () => {
 })
 
 test('produces some stats', async (t) => {
+  t.plan(2)
+
   const fastify = Fastify()
   fastify.register(Stats)
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => { fastify.close() })
 
   fastify.get('/', async () => {
     return { hello: 'world' }
@@ -29,15 +31,17 @@ test('produces some stats', async (t) => {
   await setTimeoutPromise(10)
   const measurements = fastify.measurements()
   const nums = measurements.GET['/']
-  t.ok(nums[0] >= 0)
-  t.ok(nums.length === 1)
+  t.assert.ok(nums[0] >= 0)
+  t.assert.ok(nums.length === 1)
 })
 
 test('has no conflicts with custom measures', async (t) => {
+  t.plan(2)
+
   const fastify = Fastify()
   fastify.register(Stats)
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => { fastify.close() })
 
   fastify.get('/', async () => {
     performance.mark('A')
@@ -54,15 +58,17 @@ test('has no conflicts with custom measures', async (t) => {
   await setTimeoutPromise(10)
   const measurements = fastify.measurements()
   const nums = measurements.GET['/']
-  t.ok(nums[0] >= 0)
-  t.ok(nums.length === 1)
+  t.assert.ok(nums[0] >= 0)
+  t.assert.ok(nums.length === 1)
 })
 
 test('measurements returns an array', async (t) => {
+  t.plan(4)
+
   const fastify = Fastify()
   fastify.register(Stats)
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => { fastify.close() })
 
   fastify.get('/', async () => {
     return { hello: 'world' }
@@ -83,17 +89,19 @@ test('measurements returns an array', async (t) => {
   await setTimeoutPromise(10)
   const measurements = fastify.measurements()
   const nums = measurements.GET['/']
-  t.ok(nums.length === 3)
-  t.ok(nums[0] >= 0)
-  t.ok(nums[1] >= 0)
-  t.ok(nums[2] >= 0)
+  t.assert.ok(nums.length === 3)
+  t.assert.ok(nums[0] >= 0)
+  t.assert.ok(nums[1] >= 0)
+  t.assert.ok(nums[2] >= 0)
 })
 
 test('creates stats', async (t) => {
+  t.plan(6)
+
   const fastify = Fastify()
   fastify.register(Stats)
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => { fastify.close() })
 
   fastify.get('/', async () => {
     return { hello: 'world' }
@@ -114,19 +122,21 @@ test('creates stats', async (t) => {
   await setTimeoutPromise(10)
   const stats = fastify.stats()
   const nums = stats.GET['/']
-  t.ok(nums.mean >= 0)
-  t.ok(nums.mode >= 0)
-  t.ok(nums.median >= 0)
-  t.ok(nums.max >= 0)
-  t.ok(nums.min >= 0)
-  t.ok(nums.sd >= 0)
+  t.assert.ok(nums.mean >= 0)
+  t.assert.ok(nums.mode >= 0)
+  t.assert.ok(nums.median >= 0)
+  t.assert.ok(nums.max >= 0)
+  t.assert.ok(nums.min >= 0)
+  t.assert.ok(nums.sd >= 0)
 })
 
 test('group stats together', async (t) => {
+  t.plan(8)
+
   const fastify = Fastify()
   fastify.register(Stats)
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => { fastify.close() })
 
   fastify.get('/:param/grouped-stats', { config: { statsId: 'grouped-stats' } }, async () => {
     return { hello: 'world' }
@@ -147,21 +157,23 @@ test('group stats together', async (t) => {
   await setTimeoutPromise(10)
   const stats = fastify.stats()
   const nums = stats.GET['grouped-stats']
-  t.ok(Object.keys(stats).length === 1)
-  t.ok(nums)
-  t.ok(nums.mean >= 0)
-  t.ok(nums.mode >= 0)
-  t.ok(nums.median >= 0)
-  t.ok(nums.max >= 0)
-  t.ok(nums.min >= 0)
-  t.ok(nums.sd >= 0)
+  t.assert.ok(Object.keys(stats).length === 1)
+  t.assert.ok(nums)
+  t.assert.ok(nums.mean >= 0)
+  t.assert.ok(nums.mode >= 0)
+  t.assert.ok(nums.median >= 0)
+  t.assert.ok(nums.max >= 0)
+  t.assert.ok(nums.min >= 0)
+  t.assert.ok(nums.sd >= 0)
 })
 
 test('produces stats for multiple methods', async (t) => {
+  t.plan(4)
+
   const fastify = Fastify()
   fastify.register(Stats)
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => { fastify.close() })
 
   fastify.get('/', async () => {
     return { hello: 'world', method: 'GET' }
@@ -183,19 +195,21 @@ test('produces stats for multiple methods', async (t) => {
   await setTimeoutPromise(10)
   const measurements = fastify.measurements()
   const gets = measurements.GET['/']
-  t.ok(gets[0] >= 0)
-  t.ok(gets.length === 1)
+  t.assert.ok(gets[0] >= 0)
+  t.assert.ok(gets.length === 1)
 
   const posts = measurements.POST['/']
-  t.ok(posts[0] >= 0)
-  t.ok(posts.length === 1)
+  t.assert.ok(posts[0] >= 0)
+  t.assert.ok(posts.length === 1)
 })
 
 test('produces stats for multiple routes of method', async (t) => {
+  t.plan(12)
+
   const fastify = Fastify()
   fastify.register(Stats)
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => { fastify.close() })
 
   fastify.get('/first', async () => {
     return { hello: 'world' }
@@ -224,16 +238,18 @@ test('produces stats for multiple routes of method', async (t) => {
   await setTimeoutPromise(10)
   const stats = fastify.stats()
   Object.values(stats.GET).forEach(nums => {
-    t.ok(nums.mean >= 0)
-    t.ok(nums.mode >= 0)
-    t.ok(nums.median >= 0)
-    t.ok(nums.max >= 0)
-    t.ok(nums.min >= 0)
-    t.ok(nums.sd >= 0)
+    t.assert.ok(nums.mean >= 0)
+    t.assert.ok(nums.mode >= 0)
+    t.assert.ok(nums.median >= 0)
+    t.assert.ok(nums.max >= 0)
+    t.assert.ok(nums.min >= 0)
+    t.assert.ok(nums.sd >= 0)
   })
 })
 
 test('logs stats every printInterval sec', async (t) => {
+  t.plan(3)
+
   const stream = new Transform({
     objectMode: true,
     transform: (chunk, enc, cb) => cb(null, JSON.parse(chunk))
@@ -242,7 +258,7 @@ test('logs stats every printInterval sec', async (t) => {
   const fastify = Fastify({ logger: { stream, level: 'info' } })
   fastify.register(Stats, { printInterval: 500 })
 
-  t.teardown(() => {
+  t.after(() => {
     clock.uninstall()
     fastify.close()
   })
@@ -252,14 +268,14 @@ test('logs stats every printInterval sec', async (t) => {
   })
 
   const matches = [
-    { msg: /incoming request/ },
-    { msg: /request completed/ },
-    { msg: /routes stats/ }
+    /incoming request/,
+    /request completed/,
+    /routes stats/
   ]
 
   let i = 0
   stream.on('data', line => {
-    t.match(line, matches[i], `Line ${i}`)
+    t.assert.match(line.msg, matches[i], `Line ${i}`)
     i += 1
   })
 
@@ -273,6 +289,8 @@ test('logs stats every printInterval sec', async (t) => {
 })
 
 test('reply sent in a onRequest hook before stats registered', async (t) => {
+  t.plan(1)
+
   const stream = new Transform({
     objectMode: true,
     transform: (chunk, enc, cb) => cb(null, JSON.parse(chunk))
@@ -285,14 +303,14 @@ test('reply sent in a onRequest hook before stats registered', async (t) => {
     next()
   })
 
-  const match = { msg: /missing request mark/ }
+  // const match = { msg: /missing request mark/ }
 
   stream.on('data', line => {
-    t.match(line, match, 'Line matched')
+    t.assert.match(line.msg, /missing request mark/, 'Line matched')
   })
   fastify.register(Stats)
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => { fastify.close() })
 
   fastify.get('/', async () => {
     return { hello: 'world' }

--- a/test/processPerformanceList.test.js
+++ b/test/processPerformanceList.test.js
@@ -1,147 +1,147 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const processPerformanceList = require('../lib/processPerformanceList')
 
-test('processPerformanceList', t => {
+test('processPerformanceList', async t => {
   t.plan(8)
 
-  t.test('no entries', t => {
+  await t.test('no entries', t => {
     t.plan(6)
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([]).mean,
       undefined
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([]).mode,
       undefined
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([]).median,
       undefined
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([]).max,
       undefined
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([]).min,
       undefined
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([]).sd,
       undefined
     )
   })
 
-  t.test('one entry', t => {
+  await t.test('one entry', t => {
     t.plan(6)
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([2]).mean,
       2
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([2]).mode,
       2
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([2]).median,
       2
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([2]).max,
       2
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([2]).min,
       2
     )
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([2]).sd,
       0
     )
   })
 
-  t.test('mode', t => {
+  await t.test('mode', t => {
     t.plan(6)
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([10, 11, 12, 11, 12, 7, 12]).mode,
       12
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([10, 13, 12, 13, 12, 13, 12]).mode,
       13
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2, 2, 3, 3, 3, 4]).mode,
       3
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2, 2, 3, 3, 4]).mode,
       3
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2, 2, 2, 3, 3, 4]).mode,
       2
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2, 3]).mode,
       3
     )
   })
 
-  t.test('mean', t => {
+  await t.test('mean', t => {
     t.plan(6)
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([10, 11, 12, 11, 12, 7, 12]).mean,
       75 / 7
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([10, 13, 12, 13, 12, 13, 12]).mean,
       85 / 7
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2, 2, 3, 3, 3, 4]).mean,
       18 / 7
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2, 2, 3, 3, 4]).mean,
       2.5
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2, 2, 2, 3, 3, 4]).mean,
       17 / 7
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2, 3]).mean,
       2
     )
   })
 
-  t.test('median', t => {
+  await t.test('median', t => {
     t.plan(3)
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2]).median,
       1.5
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([1, 2, 3]).median,
       2
     )
 
-    t.equal(
+    t.assert.strictEqual(
       processPerformanceList([
         2, 27, 10, 29, 16, 8, 5, 19, 2, 2, 18, 28,
         7, 28, 28, 25, 19, 14, 18, 21, 25, 29, 7,
@@ -151,20 +151,20 @@ test('processPerformanceList', t => {
     )
   })
 
-  t.test('standard deviation', t => {
+  await t.test('standard deviation', t => {
     t.plan(1)
-    t.equal(processPerformanceList([-2, -1, 0, 1, 2]).sd, Math.sqrt(2.5))
+    t.assert.strictEqual(processPerformanceList([-2, -1, 0, 1, 2]).sd, Math.sqrt(2.5))
   })
 
-  t.test('max', t => {
+  await t.test('max', t => {
     t.plan(2)
-    t.equal(processPerformanceList([-2, -1, 0, 1, 2]).max, 2)
-    t.equal(processPerformanceList([6, 10, 2, 5]).max, 10)
+    t.assert.strictEqual(processPerformanceList([-2, -1, 0, 1, 2]).max, 2)
+    t.assert.strictEqual(processPerformanceList([6, 10, 2, 5]).max, 10)
   })
 
-  t.test('min', t => {
+  await t.test('min', t => {
     t.plan(2)
-    t.equal(processPerformanceList([-2, -1, 0, 1, 2]).min, -2)
-    t.equal(processPerformanceList([6, 10, 2, 5]).min, 2)
+    t.assert.strictEqual(processPerformanceList([-2, -1, 0, 1, 2]).min, -2)
+    t.assert.strictEqual(processPerformanceList([6, 10, 2, 5]).min, 2)
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hi,

The goal of this PR is migrate the tests from Tap to Node test runner, following what's been said in the issue https://github.com/fastify/fastify/issues/5555

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

